### PR TITLE
Fix missing @s

### DIFF
--- a/src/animator.coffee
+++ b/src/animator.coffee
@@ -14,8 +14,8 @@ class Animator
   # Create initial animator for the model, specifying default rate (fps) and multiStep.
   # If multiStep, run the draw() and step() methods separately by draw() using
   # requestAnimationFrame and step() using setTimeout.
-  constructor: (@model, @rate=30, @multiStep=model.world.isHeadless) ->
-    @isHeadless = model.world.isHeadless; @reset()
+  constructor: (@model, @rate=30, @multiStep=@model.world.isHeadless) ->
+    @isHeadless = @model.world.isHeadless; @reset()
   # Adjust animator.  Call before model.start()
   # in setup() to change default settings
   setRate: (@rate, @multiStep=@isHeadless) -> @resetTimes() # Change rate while running?


### PR DESCRIPTION
Holy cow how did we never notice this? I only just discovered it when `npm install`ing from scratch and trying to run an example model. Totally borked. Must've been a bug in an older version of coffeescript that somehow let this slide?