### PR TITLE
There was a problem when resampling.

### DIFF
--- a/src/DataSet.js
+++ b/src/DataSet.js
@@ -155,8 +155,6 @@ class DataSet {
     resample(width, height, useNearest = true, Type = Array) {
         if (width === this.width && height === this.height) return this.copy()
         const ds = DataSet.emptyDataSet(width, height, Type)
-        // const xScale = (this.width - 1) / (width - 1)
-        // const yScale = (this.height - 1) / (height - 1)
         for (let y = 0; y < height; y++) {
             for (let x = 0; x < width; x++) {
                 ds.setXY(


### PR DESCRIPTION
This is one way to address the bug where resizing a dataset from 1456x1456 to 1280x1280 fails due to a numerical precision issue. 
The other way would be to clamp the coordinates instead of throwing an error. 
It is caused because in javascript: (1455/1279) * 1279 = 1455.0000000000002 , whereas (1455*1279) / 1279 = 1455 .
The number 1455.0000000000002 causes checkXY to fail. 

